### PR TITLE
Fix y axis image offset

### DIFF
--- a/src/AxisImage.ts
+++ b/src/AxisImage.ts
@@ -31,9 +31,9 @@ export class AxisImage {
       .attr("xlink:href", function (d) {
         return imageDirectory[d];
       })
-      .attr("width", size)
-      .attr("height", size)
-      .attr("x", -size)
-      .attr("y", -(size / 2));
+      .attr("width", size - 8)
+      .attr("height", size - 8)
+      .attr("x", -(size))
+      .attr("y", -((size - 8) / 2));
   }
 }


### PR DESCRIPTION
Signed-off-by: Jay Clark <jay@jayeclark.dev>

## Description

Fixes axis image component to be sized slightly smaller so that they can be offset -8px from the axis (standard tick mark is 6px wide.) Offsetting without also adjusting the sizing results in the images being cropped, as in that situation they extend beyond the axis label container.

Fixes #38 

![Screen Recording 2021-10-31 at 11 28 23 AM](https://user-images.githubusercontent.com/84106309/139590919-87fc8423-7cef-4af6-b02f-c96745fa4816.gif)


## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Style adjustment - visually verified.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings

## Next Steps
- [ ] Assign a reviewer based on the [code owner document](https://github.com/jamie-sgro/dashboard/blob/develop/.github/CODEOWNERS).

- [ ] Once your review is approved, merge and delete the feature branch

On behalf of the Cities Index Dev Team, thank you for your hard work! ✨